### PR TITLE
Remove unused find_plane_urdf function?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - Bazel: dependencies based on ``pip_parse`` from ``rules_python``
-- BulletInterface: Removed hardcoded ground plane URDF
+- BulletInterface: Removed hardcoded ground plane URDF (thanks to @boragokbakan)
 
 ## [2.1.0] - 2024-01-03
 

--- a/vulp/actuation/BulletInterface.cpp
+++ b/vulp/actuation/BulletInterface.cpp
@@ -14,16 +14,6 @@ using bazel::tools::cpp::runfiles::Runfiles;
 
 namespace vulp::actuation {
 
-std::string find_plane_urdf(const std::string argv0) {
-  std::string error;
-  std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv0, &error));
-  if (runfiles == nullptr) {
-    throw std::runtime_error(
-        "Could not retrieve the package path to plane.urdf: " + error);
-  }
-  return runfiles->Rlocation("vulp/vulp/actuation/bullet/plane/plane.urdf");
-}
-
 BulletInterface::BulletInterface(const ServoLayout& layout,
                                  const Parameters& params)
     : Interface(layout), params_(params) {


### PR DESCRIPTION
This function is now unused in Vulp.