### PR TITLE
Cast logger size to uint32 in spine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Spine: Cast `logger_.last_size()` explicitly to `uint32_t`.
 
 ## [2.3.0] - 2024-05-02
 

--- a/vulp/spine/Spine.cpp
+++ b/vulp/spine/Spine.cpp
@@ -65,7 +65,7 @@ void Spine::reset(const Dictionary& config) {
 
 void Spine::log_working_dict() {
   Dictionary& spine = working_dict_("spine");
-  spine("logger")("last_size") = logger_.last_size();
+  spine("logger")("last_size") = static_cast<uint32_t>(logger_.last_size());
   spine("state")("cycle_beginning") =
       static_cast<uint32_t>(state_cycle_beginning_);
   spine("state")("cycle_end") = static_cast<uint32_t>(state_cycle_end_);


### PR DESCRIPTION
Fixes #96 